### PR TITLE
Upgrade GitHub Actions in the CD script (`publish.yml`)

### DIFF
--- a/workflows/publish.yml
+++ b/workflows/publish.yml
@@ -16,8 +16,8 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
+      - uses: actions/checkout@v5
         with:
           python-version: ">=3.9"
       - run: pip install -r requirements.txt

--- a/workflows/publish.yml
+++ b/workflows/publish.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.x
+          python-version: ">=3.9"
       - run: pip install -r requirements.txt
       - run: mkdocs build
 

--- a/workflows/publish.yml
+++ b/workflows/publish.yml
@@ -16,8 +16,8 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/setup-python@v4
       - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: ">=3.9"
       - run: pip install -r requirements.txt


### PR DESCRIPTION
This PR upgrades the GitHub Actions in our CD GH workflow (`publish.yml`):

- `actions/checkout` to v5 from v3
- `actions/setup-python` to v6 from v4

Python version `>= 3.9` is now required.